### PR TITLE
📦 NEW: font-display swap

### DIFF
--- a/plugins/export/merge-css.js
+++ b/plugins/export/merge-css.js
@@ -17,6 +17,9 @@ module.exports = async () => {
 
 	let css = createCssString(woff2, woff2Lines)
 	css = new CleanCss().minify(css).styles
+	// Add font-display swap as recommended here https://css-tricks.com/font-display-masses/.
+	css = css.replace(/}/g, ';font-display: swap}');
+	
 	await outputFile(`./.cache/google-fonts/google-fonts.css`, css)
 }
 

--- a/plugins/export/merge-css.js
+++ b/plugins/export/merge-css.js
@@ -17,8 +17,9 @@ module.exports = async () => {
 
 	let css = createCssString(woff2, woff2Lines)
 	css = new CleanCss().minify(css).styles
+	
 	// Add font-display swap as recommended here https://css-tricks.com/font-display-masses/.
-	css = css.replace(/}/g, ';font-display: swap}');
+	css = css.replace(/}/g, ';font-display: swap}')
 	
 	await outputFile(`./.cache/google-fonts/google-fonts.css`, css)
 }


### PR DESCRIPTION
This PR adds `font-display: swap;` to each font face property. It's recommended by Lighthouse and should be merged.

For the time-being, I am using the following in `gatsby-node.js` until this is merged.

```js
const { readFile, outputFile } = require(`fs-extra`);
const filePath = `./.cache/google-fonts/google-fonts.css`;

exports.onPreBootstrap = async (_, options) => {
	// Extract URLs from CSS
	let css = await readFile(filePath, `utf8`);

	// Add font-display.
	css = css.replace(/}/g, ';font-display: swap}');
	// console.log('css', css);

	await outputFile(filePath, css);
};

```